### PR TITLE
クエリ文字列を指定して検索するAPIを実装

### DIFF
--- a/src/main/java/com/example/cafeinformation/CafeController.java
+++ b/src/main/java/com/example/cafeinformation/CafeController.java
@@ -16,7 +16,7 @@ public class CafeController {
     }
 
     @GetMapping("/cafes")
-    public List<Cafe> findByPlaces(@RequestParam String equalsWith) {
-            return cafeMapper.findByPlaceEqualsWith(equalsWith);
+    public List<Cafe> findByPlaces(@RequestParam String place) {
+            return cafeMapper.findByPlaceEqualsWith(place);
     }
 }

--- a/src/main/java/com/example/cafeinformation/CafeController.java
+++ b/src/main/java/com/example/cafeinformation/CafeController.java
@@ -1,6 +1,7 @@
 package com.example.cafeinformation;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -15,8 +16,7 @@ public class CafeController {
     }
 
     @GetMapping("/cafes")
-    public List<Cafe> getNames() {
-        List<Cafe> cafes = cafeMapper.findAll();
-        return cafes;
+    public List<Cafe> findByPlaces(@RequestParam String equalsWith) {
+            return cafeMapper.findByPlaceEqualsWith(equalsWith);
     }
 }

--- a/src/main/java/com/example/cafeinformation/CafeMapper.java
+++ b/src/main/java/com/example/cafeinformation/CafeMapper.java
@@ -12,5 +12,5 @@ public interface CafeMapper {
     List<Cafe> findAll();
 
     @Select("SELECT * FROM cafes WHERE place LIKE CONCAT(#{prefix}, '%')")
-    List<Cafe> findByPlaceEqualsWith(String prefix);
+    List<Cafe> findByPlaceEqualsWith(String place);
 }

--- a/src/main/java/com/example/cafeinformation/CafeMapper.java
+++ b/src/main/java/com/example/cafeinformation/CafeMapper.java
@@ -10,4 +10,7 @@ public interface CafeMapper {
 
     @Select("SELECT * FROM cafes")
     List<Cafe> findAll();
+
+    @Select("SELECT * FROM cafes WHERE place LIKE CONCAT(#{prefix}, '%')")
+    List<Cafe> findByPlaceEqualsWith(String prefix);
 }


### PR DESCRIPTION
# 第8回課題

クエリ文字列を用いて場所を指定しそれに一致するレコードのみ出力するAPIを実装しました。

# 動作確認

・クエリ文字列で清澄白河と指定した際に場所が一致するレコードのみが出力されることを確認
・ステータスコードが200になっていることを確認
・JSON形式でのレスポンスになっていることを確認
・クエリ文字列の部分を渋谷に変更した時に一致するレコードに表記が変更されたことを確認
・こちらもステータスコードが200になっていることとJSON形式でのレスポンスになっていることを確認

<img width="863" alt="スクリーンショット 2024-05-08 14 34 36" src="https://github.com/Reiji-Shiode/cafe-info/assets/166202078/f486f115-e93a-4d5a-b9e5-3d634d41e9c7">

<img width="849" alt="スクリーンショット 2024-05-08 14 34 52" src="https://github.com/Reiji-Shiode/cafe-info/assets/166202078/28fca4da-4cbf-41c6-a72c-a1a61fbe9b7f">

<img width="865" alt="スクリーンショット 2024-05-08 14 35 28" src="https://github.com/Reiji-Shiode/cafe-info/assets/166202078/ecb5f5df-f622-443a-b998-174d3205acf2">

<img width="871" alt="スクリーンショット 2024-05-08 14 35 40" src="https://github.com/Reiji-Shiode/cafe-info/assets/166202078/82c84817-abae-44b8-8f3f-8317968219a6">

